### PR TITLE
CSS URL case mismatch fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,8 +16,7 @@ module.exports = function (grunt) {
                 undef: true,
                 boss: true,
                 eqnull: true,
-                node: true,
-                es5: true
+                node: true
             }
         },
         oversprite: {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,10 @@
     },
     "devDependencies": {
         "grunt": "~0.4.0",
-        "grunt-contrib-jshint": "0.3.5"
+        "grunt-contrib-jshint": "0.5.4"
     },
-    "repositories": [
-        {
+    "repository": {
             "type": "git",
             "url": "https://github.com/iAdramelk/grunt-oversprite.git"
-        }
-    ]
+    }
 }

--- a/tasks/grunt-oversprite.js
+++ b/tasks/grunt-oversprite.js
@@ -94,7 +94,7 @@ module.exports = function ( grunt ) {
 
                     for ( var key in result.coordinates ) {
 
-                        var newKey = path.join( process.cwd(), key );
+                        var newKey = path.join( process.cwd(), key ).toLowerCase();
 
                         imageReplaces[ newKey ] = tmpResult[ key ];
 
@@ -131,6 +131,7 @@ module.exports = function ( grunt ) {
                     pathToResource = resources[x].replace( regex, '$1' );
 
                     absolutePath = ( base ) ? path.join( base, pathToResource ) : path.join( dir, pathToResource );
+                    absolutePath = absolutePath.toLowerCase();
 
                     if ( imageReplaces[ absolutePath ] !== undefined ) {
 


### PR DESCRIPTION
This fixes a bug where CSS URLs aren't replaced if the physical file path's casing differs from the CSS URL's casing.

For example, if the physical path to a file is `Images/pic.png` but the CSS has `url('images/pic.png')`, the CSS wasn't being updated for this URL.
